### PR TITLE
Adding 'celerybeat_status' namespace to urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ from django.conf.urls import url, include
 
 urlpatterns = [
   # other urls...
-  url(r'^admin/statuscheck/', include('celerybeat_status.urls')),
+  url(r'^admin/statuscheck/', include('celerybeat_status.urls', namespce='celerybeat_status')),
 ]
 ```
 

--- a/celerybeat_status/templates/celerybeat_status/custom_admin/sidebar_widgets/statuscheck.html
+++ b/celerybeat_status/templates/celerybeat_status/custom_admin/sidebar_widgets/statuscheck.html
@@ -3,6 +3,6 @@
 <div class="module" id="status-check-links">
   <h2> {% trans 'Status check links' %} </h2>
   <ul>
-    <li><a href="{% url 'periodic-tasks-status' %}">Periodic tasks status</a></li>
+    <li><a href="{% url 'celerybeat_status:periodic-tasks-status' %}">Periodic tasks status</a></li>
   </ul>
 </div>


### PR DESCRIPTION
Hey everyone. I have the following scenario:

In my project we use the `django-celerybeat-status` with the` django-js-reverse`. As we have a hash url instead of the regular `/ admin`. The `django-js-reverse` was exposing that private hash because of the` django-celerybeat-status`. So in order to fix that, I started using namespaces (as `django-js-reverse` recommends). But the `django-celerybeat-status` does not expect that and raised a` NoReverseMatch˜ error on admin. It should be nice if we have a namespace there, also for many other reasons besides my own haha. 

I tried to have a way for that namespace to be optional trhough a settings config but I gave up on that because it was getting to ugly.