### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ from django.conf.urls import url, include
 
 urlpatterns = [
   # other urls...
-  url(r'^admin/statuscheck/', include('celerybeat_status.urls', namespce='celerybeat_status')),
+  url(r'^admin/statuscheck/', include('celerybeat_status.urls', namespace='celerybeat_status')),
 ]
 ```
 


### PR DESCRIPTION
'namespace' was misspelled as 'namespce'.